### PR TITLE
fix(kms, redis): JwtKeyManager, application-dev.yml, RedisConfig - infra 코드

### DIFF
--- a/src/main/java/app/global/config/RedisConfig.java
+++ b/src/main/java/app/global/config/RedisConfig.java
@@ -11,8 +11,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-// import com.fasterxml.jackson.databind.ObjectMapper;
-// import com.fasterxml.jackson.databind.SerializationFeature;
 
 @Configuration
 public class RedisConfig {
@@ -23,10 +21,10 @@ public class RedisConfig {
 	@Value("${REDIS_PORT}")
 	private int redisPort;
 
-	@Value("${REDIS_PASSWORD:}") // 빈 문자열 기본값
+	@Value("${REDIS_PASSWORD:}")
 	private String redisPassword;
 
-	@Value("${REDIS_PROTOCOL}")
+	@Value("${REDIS_PROTOCOL:redis}")
 	private String redisProtocol;
 
 	@Bean
@@ -47,10 +45,6 @@ public class RedisConfig {
 		if ("rediss".equalsIgnoreCase(redisProtocol)) {
 			clientConfigBuilder.useSsl();
 		}
-
-		// if ("rediss".equalsIgnoreCase(redisProtocol) || redisPort == 6380) {
-		// 	clientConfigBuilder.useSsl();
-		// }
 
 		LettuceClientConfiguration clientConfig = clientConfigBuilder.build();
 		return new LettuceConnectionFactory(redisConfig, clientConfig);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,5 +21,5 @@ jwt:
 
 kms:
   jwt:
-    key-id: ${KMS_JWT_KEY_ID}
+    key-id: ${KMS_JWT_KEY_ID:default}
     enabled: false


### PR DESCRIPTION
## 👍 작업 내용

- [x] ~ dev환경에서 안 돌아가는 dev 코드(선혁님이 push하신거 수정)

1. application-dev.yml
2. key-id: ${KMS_JWT_KEY_ID:default} 적용
3. KMS Bean 생성 시 Empty 에러 방지
4. RedisConfig.java
5. ${REDIS_PROTOCOL:redis} 기본값 지정
6. PlaceholderResolutionException 문제 해결

✅ PR Point

Redis SSL/Protocol 관련 설정이 올바르게 동작하는지 확인
KMS Bean 생성 시 기본값으로 정상 초기화되는지 확인
